### PR TITLE
fix: delete unused option description

### DIFF
--- a/tutorial/thanosql_ml/regression/automl_regression.ipynb
+++ b/tutorial/thanosql_ml/regression/automl_regression.ipynb
@@ -426,7 +426,6 @@
     "            <li>\"target_col\": 회귀 예측 모델의 목푯값이 담겨 있는 컬럼명 (str, default: 'target')</li>\n",
     "            <li>\"impute_type\": 데이터 테이블의 빈 값(NaN)을 처리하는 방법 설정 (str, optional, 'simple'|'iterative', default: 'simple')</li>\n",
     "            <li>\"datetime_attribs\": 날짜 형식의 데이터가 담겨 있는 컬럼명 리스트 (list[str], optional)</li>\n",
-    "            <li>\"outlier_method\": 데이터 테이블에서 이상치를 처리하는 방법을 설정합니다. None일 경우, 데이터 테이블은 이상치를 포함합니다. (str, optional, 'knn'|'iso'|'pca', default: None)</li>\n",
     "            <li>\"time_left_for_this_task\": 적합한 회귀 예측 모델을 찾는데 소요되는 초 단위 시간 (int, optional, default: 60)</li>\n",
     "            <li>\"overwrite\": 동일 이름의 모델이 존재하는 경우 덮어쓰기 가능 유무 설정. True일 경우 기존 모델은 새로운 모델로 변경됨 (bool, optional, True|False, default: False)</li>\n",
     "        </ul>\n",
@@ -843,11 +842,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9 (tags/v3.10.9:1dd9be6, Dec  6 2022, 20:01:21) [MSC v.1934 64 bit (AMD64)]"
+   "version": "3.9.13 (v3.9.13:6de2ca5339, May 17 2022, 11:37:23) \n[Clang 13.0.0 (clang-1300.0.29.30)]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "54a1ec72395a4a5a649013bb47cb6c1a711fb4b3d33a07524a09f31d6d2ee0ec"
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
    }
   }
  },

--- a/tutorial_en/thanosql_ml/classification/automl_classification.ipynb
+++ b/tutorial_en/thanosql_ml/classification/automl_classification.ipynb
@@ -440,7 +440,6 @@
     "            <li>\"target_col\": the name of the column containing the target value of the classification model (str, default: 'target') </li>\n",
     "            <li>\"impute_type\": determines how empty values ​​(NaNs) are handled (str, optional, 'simple'|'iterative' , default: 'simple') </li>\n",
     "            <li>\"features_to_drop\": selects columns that cannot be used for training (list[str], optional)</li>\n",
-    "            <li>\"outlier_method\": determines how outliers are handled in the table. If None, the table includes outliers (str, optional, 'knn'|'iso'|'pca', default: None) </li>\n",
     "            <li>\"time_left_for_this_task\": the total time given to find a suitable classification model in seconds (int, optional, default: 60)</li>\n",
     "            <li>\"overwrite\": determines whether to overwrite a model if it already exists. If set as True, the old model is replaced with the new model (bool, optional, True|False, default: False)</li>\n",
     "        </ul>\n",
@@ -920,11 +919,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9 (tags/v3.10.9:1dd9be6, Dec  6 2022, 20:01:21) [MSC v.1934 64 bit (AMD64)]"
+   "version": "3.9.13 (v3.9.13:6de2ca5339, May 17 2022, 11:37:23) \n[Clang 13.0.0 (clang-1300.0.29.30)]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "54a1ec72395a4a5a649013bb47cb6c1a711fb4b3d33a07524a09f31d6d2ee0ec"
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
    }
   }
  },


### PR DESCRIPTION
# Description (개요) 

선근님께서 수정해주신 내용에서 outlier_method는 코드에 포함이 안되어있어서 다시 뺐습니다. 코드에도 추가하고 설명을 추가하는게 나을지 아니면 둘 다 빼는게 나을지 정해야겠네요. @sk37025 @inwookie 

## Keep in Mind

If you are creating a new tutorial, your first commit should always be a copy of the tutorial template. This will allow reviewers to see what has been changed from the template, making the review process much more efficient.

## Type of change (작업사항)

Please delete options that are not relevant and check out the type of change.

- [x] Tutorial fix 

Following templates can be found from the [Tech-wiki Tutorial](https://github.com/smartmind-team/tech-wiki/tree/main/project/thanosql/tutorial). 


## Writing Convention

Make sure to check out the [Writing Convention](https://github.com/smartmind-team/tech-wiki/blob/main/project/thanosql/docs/writing_convention.md). 

## Review Process

Review should be conducted by at least two people.