### PR TITLE
update: COPY examples changed as 'overwrite' converted to 'if_exists'

### DIFF
--- a/templates/tutorial_ml_template.ipynb
+++ b/templates/tutorial_ml_template.ipynb
@@ -149,7 +149,7 @@
    "source": [
     "%%thanosql\n",
     "COPY {table name}\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'location of csv file'"
    ]
   },
@@ -171,11 +171,12 @@
     "(e.g.)\n",
     "%%thanosql\n",
     "COPY titanic_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/titanic_data/titanic_test.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e145f1f4-00cc-4579-84c7-24e87d97cda7",
    "metadata": {
@@ -188,7 +189,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/templates/tutorial_ml_template_ko.ipynb
+++ b/templates/tutorial_ml_template_ko.ipynb
@@ -149,7 +149,7 @@
    "source": [
     "%%thanosql\n",
     "COPY {테이블 이름}\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'csv 파일 위치'"
    ]
   },
@@ -173,7 +173,7 @@
     "(예시)\n",
     "%%thanosql\n",
     "COPY titanic_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/titanic_data/titanic_test.csv'"
    ]
   },
@@ -189,7 +189,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/templates/tutorial_search_template.ipynb
+++ b/templates/tutorial_search_template.ipynb
@@ -150,7 +150,7 @@
    "source": [
     "%%thanosql\n",
     "COPY {table name}\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'location of csv file'"
    ]
   },
@@ -172,11 +172,12 @@
     "(e.g.)\n",
     "%%thanosql\n",
     "COPY mnist_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/mnist_data/mnist_test.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e145f1f4-00cc-4579-84c7-24e87d97cda7",
    "metadata": {
@@ -189,7 +190,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/templates/tutorial_search_template_ko.ipynb
+++ b/templates/tutorial_search_template_ko.ipynb
@@ -149,7 +149,7 @@
    "source": [
     "%%thanosql\n",
     "COPY {테이블 이름}\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'csv 파일 위치'"
    ]
   },
@@ -171,7 +171,7 @@
     "(예시)\n",
     "%%thanosql\n",
     "COPY mnist_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/mnist_data/mnist_test.csv'"
    ]
   },
@@ -187,7 +187,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial/thanosql_ml/audio_recognition/speech_recognition.ipynb
+++ b/tutorial/thanosql_ml/audio_recognition/speech_recognition.ipynb
@@ -146,7 +146,7 @@
    "source": [
     "%%thanosql\n",
     "COPY librispeech_train\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/librispeech_data/librispeech_train.csv'"
    ]
   },
@@ -167,7 +167,7 @@
    "source": [
     "%%thanosql\n",
     "COPY librispeech_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/librispeech_data/librispeech_test.csv'"
    ]
   },
@@ -183,7 +183,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial/thanosql_ml/audio_recognition/speech_recognition2.ipynb
+++ b/tutorial/thanosql_ml/audio_recognition/speech_recognition2.ipynb
@@ -145,7 +145,7 @@
    "source": [
     "%%thanosql\n",
     "COPY korean_voice\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/korean_voice_data/korean_voice.csv'"
    ]
   },
@@ -161,7 +161,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial/thanosql_ml/classification/automl_classification.ipynb
+++ b/tutorial/thanosql_ml/classification/automl_classification.ipynb
@@ -151,7 +151,7 @@
    "source": [
     "%%thanosql\n",
     "COPY titanic_train\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/titanic_data/titanic_train.csv'"
    ]
   },
@@ -174,7 +174,7 @@
    "source": [
     "%%thanosql\n",
     "COPY titanic_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/titanic_data/titanic_test.csv'"
    ]
   },
@@ -190,7 +190,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial/thanosql_ml/classification/image_classification.ipynb
+++ b/tutorial/thanosql_ml/classification/image_classification.ipynb
@@ -163,7 +163,7 @@
    "source": [
     "%%thanosql\n",
     "COPY product_image_train\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/product_image_data/product_image_train.csv'"
    ]
   },
@@ -186,7 +186,7 @@
    "source": [
     "%%thanosql\n",
     "COPY product_image_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/product_image_data/product_image_test.csv'"
    ]
   },
@@ -202,7 +202,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial/thanosql_ml/classification/text_classification.ipynb
+++ b/tutorial/thanosql_ml/classification/text_classification.ipynb
@@ -155,7 +155,7 @@
    "source": [
     "%%thanosql\n",
     "COPY movie_review_train\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/movie_review_data/movie_review_train.csv'"
    ]
   },
@@ -176,7 +176,7 @@
    "source": [
     "%%thanosql\n",
     "COPY movie_review_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/movie_review_data/movie_review_test.csv'"
    ]
   },
@@ -192,7 +192,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial/thanosql_ml/question_answering/visual_question_answering.ipynb
+++ b/tutorial/thanosql_ml/question_answering/visual_question_answering.ipynb
@@ -138,7 +138,7 @@
    "source": [
     "%%thanosql\n",
     "COPY coco_person_data\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/coco_person_data/coco_person.csv'"
    ]
   },
@@ -154,7 +154,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial/thanosql_ml/regression/automl_regression.ipynb
+++ b/tutorial/thanosql_ml/regression/automl_regression.ipynb
@@ -148,7 +148,7 @@
    "source": [
     "%%thanosql\n",
     "COPY bike_sharing_train\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/bike_sharing_data/bike_sharing_train.csv'"
    ]
   },
@@ -171,7 +171,7 @@
    "source": [
     "%%thanosql\n",
     "COPY bike_sharing_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/bike_sharing_data/bike_sharing_test.csv'"
    ]
   },
@@ -187,7 +187,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial/thanosql_ml/timeseries/timeseries_forecasting.ipynb
+++ b/tutorial/thanosql_ml/timeseries/timeseries_forecasting.ipynb
@@ -138,7 +138,7 @@
    "source": [
     "%%thanosql\n",
     "COPY elec_usage_train\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/electricity_usage_data/electricity_usage_train.csv'"
    ]
   },
@@ -161,7 +161,7 @@
    "source": [
     "%%thanosql\n",
     "COPY elec_usage_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/electricity_usage_data/electricity_usage_test.csv'"
    ]
   },
@@ -177,7 +177,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial/thanosql_ml/udm_tutorial.ipynb
+++ b/tutorial/thanosql_ml/udm_tutorial.ipynb
@@ -418,7 +418,7 @@
    "source": [
     "%%thanosql\n",
     "COPY beans_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'test_data.pkl'"
    ]
   },
@@ -433,7 +433,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial/thanosql_search/search_image_by_image.ipynb
+++ b/tutorial/thanosql_search/search_image_by_image.ipynb
@@ -138,7 +138,7 @@
    "source": [
     "%%thanosql\n",
     "COPY mnist_train\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/mnist_data/mnist_train.csv'"
    ]
   },
@@ -159,11 +159,12 @@
    "source": [
     "%%thanosql\n",
     "COPY mnist_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/mnist_data/mnist_test.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d6845948",
    "metadata": {},
@@ -174,7 +175,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial/thanosql_search/search_image_by_keyword.ipynb
+++ b/tutorial/thanosql_search/search_image_by_keyword.ipynb
@@ -153,11 +153,12 @@
    "source": [
     "%%thanosql\n",
     "COPY diet\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/diet_data/diet.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8c02be61",
    "metadata": {},
@@ -168,7 +169,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial/thanosql_search/search_image_by_text.ipynb
+++ b/tutorial/thanosql_search/search_image_by_text.ipynb
@@ -133,11 +133,12 @@
    "source": [
     "%%thanosql\n",
     "COPY unsplash_data\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/unsplash_data/unsplash.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6f67fae5",
    "metadata": {},
@@ -148,7 +149,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial/thanosql_search/search_text_by_text.ipynb
+++ b/tutorial/thanosql_search/search_text_by_text.ipynb
@@ -136,7 +136,7 @@
    "source": [
     "%%thanosql\n",
     "COPY nsmc_train\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/nsmc_data/nsmc_sample_train.csv'"
    ]
   },
@@ -159,11 +159,12 @@
    "source": [
     "%%thanosql\n",
     "COPY nsmc_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/nsmc_data/nsmc_sample_test.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "cd37e5b7-d1ac-41a6-8a11-64059b1f7c7f",
    "metadata": {},
@@ -174,7 +175,7 @@
     "        <li>\"<strong>COPY</strong>\" 쿼리 구문을 사용하여 데이터베이스에 저장 할 테이블명을 지정합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 <strong>COPY</strong>에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"overwrite\": 동일 이름의 테이블이 데이터베이스 상에 존재하는 경우 덮어쓰기 가능 여부 설정. True일 경우 기존 테이블은 새로운 테이블로 변경됨 (bool, optional, True|False, default: False)</li>\n",
+    "            <li>\"if_exists\": 동일 이름의 테이블이 존재하는 경우 처리하는 방법 설정. 오류 발생, 기존 테이블에 추가, 기존 테이블 대체 (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial_en/thanosql_ml/audio_recognition/speech_recognition.ipynb
+++ b/tutorial_en/thanosql_ml/audio_recognition/speech_recognition.ipynb
@@ -143,7 +143,7 @@
    "source": [
     "%%thanosql\n",
     "COPY librispeech_train \n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/librispeech_data/librispeech_train.csv'"
    ]
   },
@@ -164,11 +164,12 @@
    "source": [
     "%%thanosql\n",
     "COPY librispeech_test \n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/librispeech_data/librispeech_test.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "984aefd3",
    "metadata": {},
@@ -179,7 +180,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial_en/thanosql_ml/audio_recognition/speech_recognition2.ipynb
+++ b/tutorial_en/thanosql_ml/audio_recognition/speech_recognition2.ipynb
@@ -139,11 +139,12 @@
    "source": [
     "%%thanosql\n",
     "COPY korean_voice\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/korean_voice_data/korean_voice.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c727ada5",
    "metadata": {},
@@ -154,7 +155,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial_en/thanosql_ml/classification/automl_classification.ipynb
+++ b/tutorial_en/thanosql_ml/classification/automl_classification.ipynb
@@ -147,7 +147,7 @@
    "source": [
     "%%thanosql\n",
     "COPY titanic_train \n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/titanic_data/titanic_train.csv'"
    ]
   },
@@ -168,11 +168,12 @@
    "source": [
     "%%thanosql\n",
     "COPY titanic_test \n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/titanic_data/titanic_test.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "984aefd3",
    "metadata": {},
@@ -183,7 +184,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial_en/thanosql_ml/classification/image_classification.ipynb
+++ b/tutorial_en/thanosql_ml/classification/image_classification.ipynb
@@ -162,7 +162,7 @@
    "source": [
     "%%thanosql\n",
     "COPY product_image_train\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/product_image_data/product_image_train.csv'"
    ]
   },
@@ -185,11 +185,12 @@
    "source": [
     "%%thanosql\n",
     "COPY product_image_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/product_image_data/product_image_test.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "984aefd3",
    "metadata": {},
@@ -200,7 +201,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial_en/thanosql_ml/classification/text_classification.ipynb
+++ b/tutorial_en/thanosql_ml/classification/text_classification.ipynb
@@ -152,7 +152,7 @@
    "source": [
     "%%thanosql\n",
     "COPY movie_review_train\n",
-    "OPTIONS (overwrite=True) \n",
+    "OPTIONS (if_exists='replace') \n",
     "FROM 'thanosql-dataset/movie_review_data/movie_review_train.csv'"
    ]
   },
@@ -173,11 +173,12 @@
    "source": [
     "%%thanosql\n",
     "COPY movie_review_test \n",
-    "OPTIONS (overwrite=True) \n",
+    "OPTIONS (if_exists='replace') \n",
     "FROM 'thanosql-dataset/movie_review_data/movie_review_test.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "984aefd3",
    "metadata": {},
@@ -188,7 +189,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial_en/thanosql_ml/question_answering/visual_question_answering.ipynb
+++ b/tutorial_en/thanosql_ml/question_answering/visual_question_answering.ipynb
@@ -136,11 +136,12 @@
    "source": [
     "%%thanosql\n",
     "COPY coco_person_data \n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/coco_person_data/coco_person.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6f67fae5",
    "metadata": {},
@@ -151,7 +152,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial_en/thanosql_ml/regression/automl_regression.ipynb
+++ b/tutorial_en/thanosql_ml/regression/automl_regression.ipynb
@@ -148,7 +148,7 @@
    "source": [
     "%%thanosql\n",
     "COPY bike_sharing_train \n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/bike_sharing_data/bike_sharing_train.csv'"
    ]
   },
@@ -171,11 +171,12 @@
    "source": [
     "%%thanosql\n",
     "COPY bike_sharing_test \n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/bike_sharing_data/bike_sharing_test.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "984aefd3",
    "metadata": {},
@@ -186,7 +187,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial_en/thanosql_ml/timeseries/timeseries_forecasting.ipynb
+++ b/tutorial_en/thanosql_ml/timeseries/timeseries_forecasting.ipynb
@@ -138,7 +138,7 @@
    "source": [
     "%%thanosql\n",
     "COPY elec_usage_train\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/electricity_usage_data/electricity_usage_train.csv'"
    ]
   },
@@ -161,7 +161,7 @@
    "source": [
     "%%thanosql\n",
     "COPY elec_usage_test\n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/electricity_usage_data/electricity_usage_test.csv'"
    ]
   },
@@ -177,7 +177,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial_en/thanosql_ml/udm_tutorial.ipynb
+++ b/tutorial_en/thanosql_ml/udm_tutorial.ipynb
@@ -404,11 +404,12 @@
    "source": [
     "%%thanosql\n",
     "COPY beans_test \n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'test_data.pkl'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -418,7 +419,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial_en/thanosql_search/search_image_by_image.ipynb
+++ b/tutorial_en/thanosql_search/search_image_by_image.ipynb
@@ -140,7 +140,7 @@
    "source": [
     "%%thanosql\n",
     "COPY mnist_train \n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/mnist_data/mnist_train.csv'"
    ]
   },
@@ -161,11 +161,12 @@
    "source": [
     "%%thanosql\n",
     "COPY mnist_test \n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/mnist_data/mnist_test.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d6845948",
    "metadata": {},
@@ -176,7 +177,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial_en/thanosql_search/search_image_by_keyword.ipynb
+++ b/tutorial_en/thanosql_search/search_image_by_keyword.ipynb
@@ -153,11 +153,12 @@
    "source": [
     "%%thanosql\n",
     "COPY diet \n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/diet_data/diet.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8c02be61",
    "metadata": {},
@@ -168,7 +169,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial_en/thanosql_search/search_image_by_text.ipynb
+++ b/tutorial_en/thanosql_search/search_image_by_text.ipynb
@@ -133,11 +133,12 @@
    "source": [
     "%%thanosql\n",
     "COPY unsplash_data \n",
-    "OPTIONS (overwrite=True)\n",
+    "OPTIONS (if_exists='replace')\n",
     "FROM 'thanosql-dataset/unsplash_data/unsplash.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d6845948",
    "metadata": {},
@@ -148,7 +149,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",

--- a/tutorial_en/thanosql_search/search_text_by_text.ipynb
+++ b/tutorial_en/thanosql_search/search_text_by_text.ipynb
@@ -140,7 +140,7 @@
    "source": [
     "%%thanosql\n",
     "COPY movie_review_train\n",
-    "OPTIONS (overwrite=True) \n",
+    "OPTIONS (if_exists='replace') \n",
     "FROM 'thanosql-dataset/movie_review_data/movie_review_train.csv'"
    ]
   },
@@ -163,11 +163,12 @@
    "source": [
     "%%thanosql\n",
     "COPY movie_review_test \n",
-    "OPTIONS (overwrite=True) \n",
+    "OPTIONS (if_exists='replace') \n",
     "FROM 'thanosql-dataset/movie_review_data/movie_review_test.csv'"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "cd37e5b7-d1ac-41a6-8a11-64059b1f7c7f",
    "metadata": {},
@@ -178,7 +179,7 @@
     "        <li>\"<strong>COPY</strong>\" specifies the name of the dataset to be saved as a database table.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for the <strong>COPY</strong> clause.\n",
     "        <ul>\n",
-    "           <li>\"overwrite\": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)</li>\n",
+    "           <li>\"if_exists\": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",


### PR DESCRIPTION
# Description (개요) 

Related to: [ThanoSQL Engine PR #192](https://github.com/smartmind-team/thanosql-engine/pull/192) 
From the above PR, ThanoSQL COPY clause's 'overwrite' functionality has been replaced by the 'if_exists'. Therefore, this PR has been created to implement the changes. 

Also related to: [ThanoSQL Docs PR #179](https://github.com/smartmind-team/thanosql-docs/pull/179)

## Keep in Mind

If you are creating a new tutorial, your first commit should always be a copy of the tutorial template. This will allow reviewers to see what has been changed from the template, making the review process much more efficient.

## Type of change (작업사항)

- [x] Tutorial fix 

Following templates can be found from the [Tech-wiki Tutorial](https://github.com/smartmind-team/tech-wiki/tree/main/project/thanosql/tutorial). 


## Writing Convention

Make sure to check out the [Writing Convention](https://github.com/smartmind-team/tech-wiki/blob/main/project/thanosql/docs/writing_convention.md). 

## Review Process

Review should be conducted by at least two people.