### PR TITLE
hot-fix: table_name deleted from udm tutorials (#87)

### DIFF
--- a/tutorial/thanosql_ml/udm_tutorial.ipynb
+++ b/tutorial/thanosql_ml/udm_tutorial.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -40,6 +41,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -47,6 +49,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -54,6 +57,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -88,6 +92,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -106,6 +111,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -157,6 +163,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -164,6 +171,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -256,6 +264,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -278,6 +287,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -335,6 +345,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -441,6 +452,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -547,6 +559,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -616,6 +629,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -718,7 +732,6 @@
     "%%thanosql\n",
     "PREDICT USING beans_mobilevit\n",
     "OPTIONS (\n",
-    "    table_name='beans_test',\n",
     "    result_col='predicted'\n",
     "    )\n",
     "AS (\n",
@@ -740,7 +753,6 @@
     "        <li>\"<strong>PREDICT USING</strong>\" 쿼리 구문을 사용하여 <strong>beans_mobilevit</strong> 모델을 예측에 사용합니다.</li>\n",
     "        <li>\"<strong>OPTIONS</strong>\" 쿼리 구문을 통해 예측에 사용할 옵션을 지정합니다.\n",
     "        <ul>\n",
-    "            <li>\"table_name\": ThanoSQL 워크스페이스 데이터베이스 내에 저장될 테이블 이름. 기존에 사용한 테이블 이름으로 지정할 경우, 기존 테이블은 'predict_result' 컬럼을 추가한 테이블로 대체. 지정하지 않을 시 테이블을 저장하지 않음 (str, optional)</li>\n",
     "            <li>\"result_col\": 데이터 테이블에서 예측 결과를 담을 컬럼 이름 (str, optional, default: 'predict_result')</li>\n",
     "        </ul>\n",
     "        </li>\n",

--- a/tutorial_en/thanosql_ml/udm_tutorial.ipynb
+++ b/tutorial_en/thanosql_ml/udm_tutorial.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -39,6 +40,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -46,6 +48,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -53,6 +56,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -86,6 +90,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -102,6 +107,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -152,6 +158,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -159,6 +166,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -247,6 +255,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -269,6 +278,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -324,6 +334,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -355,6 +366,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -374,6 +386,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -427,6 +440,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -519,6 +533,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -532,6 +547,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -572,6 +588,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -590,6 +607,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -599,6 +617,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -700,8 +719,7 @@
     "%%thanosql\n",
     "PREDICT USING beans_mobilevit\n",
     "OPTIONS (\n",
-    "    result_col='predicted',\n",
-    "    table_name='beans_test'\n",
+    "    result_col='predicted'\n",
     "    )\n",
     "AS (\n",
     "    SELECT *\n",
@@ -722,7 +740,6 @@
     "        <li>\"<strong>OPTIONS</strong>\" specifies the option values to be used for prediction.\n",
     "        <ul>\n",
     "            <li>\"result_col\": the column that contains the predicted results (str, optional, default: 'predict_result')</li>\n",
-    "            <li>\"table_name\": the table name to be stored in the ThanoSQL workspace database. If a previously used table is specified, the existing table will be replaced by the new table with a 'predict_result' column. If not specified, the result dataframe will not be saved as a data table (str, optional)</li>\n",
     "        </ul>\n",
     "        </li>\n",
     "    </ul>\n",
@@ -819,6 +836,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
# Description (개요) 

`table_name` from UDM tutorials deleted as such feature is no longer supported. 

## Keep in Mind

If you are creating a new tutorial, your first commit should always be a copy of the tutorial template. This will allow reviewers to see what has been changed from the template, making the review process much more efficient.

## Type of change (작업사항)

- [x] Tutorial fix 

Following templates can be found from the [Tech-wiki Tutorial](https://github.com/smartmind-team/tech-wiki/tree/main/project/thanosql/tutorial). 


## Writing Convention

Make sure to check out the [Writing Convention](https://github.com/smartmind-team/tech-wiki/blob/main/project/thanosql/docs/writing_convention.md). 

## Review Process

Review should be conducted by at least two people.